### PR TITLE
fixing typo for multiqc definition in configuration

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -41,9 +41,9 @@ params {
     // MultiQC options
     max_multiqc_email_size     = '25.MB'
     multiqc_title              = "BACPAQ"
-    multiqc_config             = "null"
-    multiqc_logo               = "null"
-    multiqc_methods_description= "null"
+    multiqc_config             = null
+    multiqc_logo               = null
+    multiqc_methods_description = null
 
 
 
@@ -88,6 +88,7 @@ params {
     skip_bracken               = false
     skip_kraken2               = false
     skip_combinebrackenoutputs = false
+    skip_quality_report        = false
 
     // kraken2 options
     // Path to Kraken2 database used for querying reads during taxonomic classification

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -15,7 +15,7 @@
         "input": {
           "type": "string",
           "format": "file-path",
-          "mimetype": "text/csv",
+          "mimetype": "csv",
           "pattern": "^\\S+\\.csv$",
           "schema": "assets/schema_input.json",
           "description": "Path to comma-separated file containing information about the samples in the experiment.",
@@ -27,8 +27,7 @@
           "type": "string",
           "format": "directory-path",
           "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
-          "fa_icon": "fas fa-folder-open",
-          "default": "results"
+          "fa_icon": "fas fa-folder-open"
         },
         "email": {
           "type": "string",


### PR DESCRIPTION
`ERROR nextflow.cli.Launcher - Is a directory java.io.IOException: Is a directory`

The error is in result of multiqc_config defined as directory but a default string value is defined in the configuration