### PR TITLE
95 remove hardcoded nextflowconfig paths

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -437,11 +437,12 @@ process {
             mode: params.publish_dir_mode,
             pattern: '*'
         ]
-        ext.args = "-s ${params.resfinder_species} \
+        ext.args = { (params.resfinder_species == "other" ? '' : "--point" ) + 
+                    "-s ${params.resfinder_species} \
                     --acquired \
-                    --point \
                     --db_path_res ${params.resfinder_db} \
-                    --db_path_point ${params.pointfinder_db}"
+                    --db_path_point ${params.pointfinder_db}" 
+                    }
     }
 
     withName: ABRICATE_RUN {

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,7 +30,7 @@ params {
     skip_seqqc                = false
     skip_trimming             = false
     trim_tool                 = "fastp"     // Select which trimming tool to use (fastp/trimmomatic/trimgalore)
-    adapter_fasta             = null        // location for adapator database (fasta file)
+    adapter_fasta             = "null"      // location for adapator database (fasta file)
     save_trimmed_fail         = false       // Check if reads failed in the trimming process need to be saved (True/False, default: False)
     save_merged               = true        // Check if merged reads need to be saved (True/False, default: True)
 
@@ -49,7 +49,6 @@ params {
 
     // PycoQC options
     nanopore_summary_file      = null       // Path to nanopore summary file to be used by PycoQC
-    nanopore_summary_file_id   = 'test'     // ID for nanopore summary file to be used by PycoQC
 
     // Assembly options (Dragonflye/Shovill)
     // Estimated genome size, e.g. 3.2M (autodetect: blank)

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,76 +8,61 @@
 
 // Global default params, used in configs
 params {
-    // TODO nf-core: Specify your pipeline's command line flags
-
 
     // Input options
-    input                     = null // location for the input samplesheet file
+    input                     = null        // location for the input samplesheet file
     classifier                = "kraken2"
     fasta                     = "test.fa"
-    schema_ignore_params      = "fasta"
     tracedir                  = "null"
 
     //rasusa subsampling options
     skip_subsampling           = true
-    depth_cut_off             = '50' // minimum coverage to subsample the reads is 50
+    depth_cut_off              = '50'        // minimum coverage to subsample the reads is 50
 
     // assembly_qc: genomesize is used by confindr for spec
-    subsampling_genomesize    = 5000000 // change name - de-group from reads reference genome size. Valid metric suffixes include Base (b), Kilo (k), Mega (m), Giga (g), Tera (t)
+    subsampling_genomesize    = 5000000     // change name - de-group from reads reference genome size. Valid metric suffixes include Base (b), Kilo (k), Mega (m), Giga (g), Tera (t)
 
-    //confindr options
+    // confindr options
     skip_confindr              = false
-    confindr_db               = "/mnt/cidgoh-object-storage/database/confindr/confindr_db" //database for confindr. The default database are only for detecting contamination in Escherichia, Listeria, and Salmonella. If you want to run ConFindr on any other genera, you need to build the database following the tutorial at https://olc-bioinformatics.github.io/ConFindr/install/.
+    confindr_db                = null       // The default database is only for detecting contamination in Escherichia, Listeria, and Salmonella. If you want to run ConFindr on any other genera, you need to build the database following the tutorial at https://olc-bioinformatics.github.io/ConFindr/install/.
 
-    //QC options
+    // QC options
     skip_seqqc                = false
     skip_trimming             = false
-    trim_tool                 = "fastp"  // Select which trimming tool to use (fastp/trimmomatic/trimgalore)
-    adapter_fasta             = "/mnt/cidgoh-object-storage/database/adaptors/test.fa" // location for adapator database (fasta file)
-    save_trimmed_fail         = false //  Check if reads failed in the trimming process need to be saved (True/False, default: False)
-    save_merged               = true  // Check if merged reads need to be saved (True/False, default: True)
+    trim_tool                 = "fastp"     // Select which trimming tool to use (fastp/trimmomatic/trimgalore)
+    adapter_fasta             = null        // location for adapator database (fasta file)
+    save_trimmed_fail         = false       // Check if reads failed in the trimming process need to be saved (True/False, default: False)
+    save_merged               = true        // Check if merged reads need to be saved (True/False, default: True)
 
 
     // MultiQC options
-    max_multiqc_email_size     = '25.MB'
-    multiqc_title              = "BACPAQ"
-    multiqc_config             = null
-    multiqc_logo               = null
+    max_multiqc_email_size      = '25.MB'
+    multiqc_title               = "BACPAQ"
+    multiqc_config              = null
+    multiqc_logo                = null
     multiqc_methods_description = null
-
-
 
     // Nanopore QC options
     skip_nanocomp           = false
     skip_pycoqc             = false
     skip_porechop           = false
 
-
     // PycoQC options
-    // Path to nanopore summary file to be used by PycoQC
-    nanopore_summary_file      = "/mnt/cidgoh-object-storage/hackathon/seqqc/isolate_wgs/nanopore/run_summary/sequencing_summary_FAT24492_18678559.txt"
-    // ID for nanopore summary file to be used by PycoQC
-    nanopore_summary_file_id   = 'test'
+    nanopore_summary_file      = null       // Path to nanopore summary file to be used by PycoQC
+    nanopore_summary_file_id   = 'test'     // ID for nanopore summary file to be used by PycoQC
 
     // Assembly options (Dragonflye/Shovill)
     // Estimated genome size, e.g. 3.2M (autodetect: blank)
-    assembly_genomesize      = "''"
-    // Minimum contig length (auto: 0)
-    min_contig_len             = 500
-    // Minimum contig coverage (auto: 0)
-    min_contig_coverage        = 2
+    assembly_genomesize         = "''"
+    min_contig_len              = 500   // (auto: 0)
+    min_contig_coverage         = 2     // (auto: 0)
 
     // Dragonflye options
-    // Minimum input read length (disable: 0)
-    min_input_read_len         = 1000
-    // Minimum average sequence quality (off: 0)
-    min_input_quality          = 0
-    // Number of polishing rounds to conduct with Racon
-    racon_rounds               = 1
-    // Number of polishing rounds to conduct with Medaka (requires a model to be specified)
-    medaka_rounds              = 1
-    // Path to model to be used for Medaka
-    medaka_model               = "r941_min_fast_g507"
+    min_input_read_len         = 1000                       // Minimum input read length (disable: 0)
+    min_input_quality          = 0                          // Minimum average sequence quality (off: 0)
+    racon_rounds               = 1                          // Number of polishing rounds to conduct with Racon
+    medaka_rounds              = 1                          // Number of polishing rounds to conduct with Medaka (requires a model to be specified)
+    medaka_model               = "r941_min_fast_g507"       // Path to model to be used for Medaka
 
     // Taxonomy module options
 
@@ -91,42 +76,34 @@ params {
     skip_quality_report        = false
 
     // kraken2 options
-    // Path to Kraken2 database used for querying reads during taxonomic classification
-    kraken2_db                 = "/mnt/cidgoh-object-storage/database/minikraken2/minikraken2_v2_8GB_201904_UPDATE"
-    // Boolean for whether to output classified reads as a fastq file
-    classified_reads           = true
-    // Boolean for whether to output unclassified reads as a fastq file
-    unclassified_reads         = true
+    kraken2_db                 = null       // Path to Kraken2 database used for querying reads during taxonomic classification
+    classified_reads           = true       // Boolean for whether to output classified reads as a fastq file
+    unclassified_reads         = true       // Boolean for whether to output unclassified reads as a fastq file
 
     // centrifuge options
-    centrifuge_db              = "/mnt/cidgoh-object-storage/database/centrifuge"
+    centrifuge_db              = null
 
-    save_unaligned             = true
-    // Boolean for whether to save aligned reads to a fastq file
-    save_aligned               = true
-    // Boolean for whether to save the output as a SAM file
+    save_unaligned             = true       // Boolean for whether to save aligned reads to a fastq file
+    save_aligned               = true       // Boolean for whether to save the output as a SAM file
     sam_format                 = true
 
     // Aligner used for dehosting ('minimap2' or 'bwa')
     dehosting_aligner          = 'minimap2'
 
     // Path to (human) reference genome used for dehosting
-    host_genome                = "/mnt/cidgoh-object-storage/database/reference_genomes/human/GRCh38.p14/GCF_000001405.40/GCF_000001405.40_GRCh38.p14_genomic.fna"
+    host_genome                = null
 
     // ID/name for reference genome
     host_genome_id             = 'GRCh38'
 
     // bwa options
-    // Whether to sort ('sort') or view ('view') the BAM file obtained from BWA
-    bwa_sort_bam               = 'sort'
+    bwa_sort_bam               = 'sort'     // Whether to sort ('sort') or view ('view') the BAM file obtained from BWA
 
     // minimap2 options
-    // Boolean on whether to output the alignment as a BAM file or a PAF file
-    bam_format                 = true
-    // Boolean on whether to get Minimap2 to generate CIGAR strings at the cg tag of the PAF file
-    cigar_paf_format           = false
-    // Boolean on whether to get Minimap2 to move long CIGAR strings to the cg tag in the BAM file
-    cigar_bam                  = false
+    
+    bam_format                 = true       // Boolean on whether to output the alignment as a BAM file or a PAF file
+    cigar_paf_format           = false      // Boolean on whether to get Minimap2 to generate CIGAR strings at the cg tag of the PAF file    
+    cigar_bam                  = false      // Boolean on whether to get Minimap2 to move long CIGAR strings to the cg tag in the BAM file
 
     // samtools options
     // Boolean for whether to get Samtools fastq to generate an interleaved fastq or to write to separate files
@@ -144,28 +121,26 @@ params {
     version                    = false
     validate_params            = false
     show_hidden_params         = false
-    schema_ignore_params       = 'genomes'
+    schema_ignore_params       = 'genomes,fasta'
 
     // assembly QC options
     skip_checkm                = false
     skip_quast                 = false
     skip_busco                 = false
-
-    // Shovill options
-    sr_assembler               = 'spades' // WGS_ASSEMBLY: choice of genome assembler for short read data [skesa,spades,megahit,velvet]
+    sr_assembler               = 'spades'       // WGS_ASSEMBLY: choice of genome assembler for short read data [skesa,spades,megahit,velvet]
 
     // CheckM options
-    checkm_db                  = 'null' // ASSEMBLY_QC: path to local CheckM lineages directory
+    checkm_db                  = 'null'         // ASSEMBLY_QC: path to local CheckM lineages directory
 
     // QUAST options
-    reference_genome_fasta     = "null" // ASSEMBLY_QC: path to reference genome file
-    reference_genome_gff       = "null" // ASSEMBLY_QC: path to reference genome annotation file (.GFF)
-    combine_quast              = false // ASSEMBLY_QC: whether to aggregate individual QUAST results file
+    reference_genome_fasta     = "null"         // ASSEMBLY_QC: path to reference genome file
+    reference_genome_gff       = "null"         // ASSEMBLY_QC: path to reference genome annotation file (.GFF)
+    combine_quast              = false          // ASSEMBLY_QC: whether to aggregate individual QUAST results file
 
     // BUSCO options
-    busco_lineage              = "bacteria" // ASSEMBLY_QC: the BUSCO lineage to use, or "auto" to automatically select lineage
-    busco_lineages_path        = "/mnt/cidgoh-object-storage/database/busco" // ASSEMBLY_QC: path to local BUSCO lineages directory
-    busco_config               = false // ASSEMBLY_QC: path to BUSCO config file
+    busco_lineage              = "bacteria"     // ASSEMBLY_QC: the BUSCO lineage to use, or "auto" to automatically select lineage
+    busco_lineages_path        = null           // ASSEMBLY_QC: path to local BUSCO lineages directory
+    busco_config               = false          // ASSEMBLY_QC: path to BUSCO config file
 
     // PEPPAN options
     reference_gff               = null
@@ -209,19 +184,19 @@ params {
     skip_amr_annotation         = false
     skip_rgi                    = false
     skip_abricate               = false
-    abricate_db                 = "card" // AMR: database to use for abricate
+    abricate_db                 = "card"        // AMR: database to use for abricate
     skip_abritamr               = false
     skip_amrfinderplus          = false
-    resfinder_db                = "/scratch/group_share/tmp/database/resfinder_db"
-    pointfinder_db              = "/scratch/group_share/tmp/database/pointfinder_db"
-    disinfinder_db              = "/scratch/group_share/tmp/database/disinfinder_db"
-    resfinder_species           = "ecoli"
+    resfinder_db                = null
+    pointfinder_db              = null
+    disinfinder_db              = null
+    resfinder_species           = "other"
 
     // gene annotation options
     skip_gene_annotation       = false
     skip_prokka                = false
     skip_bakta                 = false
-    bakta_db                   = "/mnt/cidgoh-object-storage/database/bakta/db/"
+    bakta_db                   = null
     prodigal_training_file     = null
     annotation_protein_file    = null
 

--- a/subworkflows/local/amr_annotation.nf
+++ b/subworkflows/local/amr_annotation.nf
@@ -95,6 +95,16 @@ workflow AMR_ANNOTATION{
         }
 
         if (!params.skip_resfinder){
+            // Resfinder db validation
+            if ( params.resfinder_db == null || !Utils.fileExists(params.resfinder_db)) {
+                log.error "Path to ResFinder database was not provided or is not valid"
+                exit 1
+                }
+            if ( params.pointfinder_db == null || !Utils.fileExists(params.pointfinder_db)) {
+                log.error "Path to PointFinder database was not provided or is not valid"
+                exit 1
+                }
+            
             RESFINDER(genome)
             resfinder_report = RESFINDER.out.resfinder_results_table
         }

--- a/subworkflows/local/assembly_qc.nf
+++ b/subworkflows/local/assembly_qc.nf
@@ -10,6 +10,23 @@ workflow ASSEMBLY_QC {
     main:
     ch_versions = Channel.empty()
 
+    //
+    // Validate database paths
+    //
+
+    if (!params.skip_checkm && params.checkm_db != null) {
+        if (!Utils.fileExists(params.checkm_db)) {
+            log.error "Path to CheckM database is not valid"
+            exit 1
+            }
+        }
+    if (!params.skip_busco) {
+        if ( params.busco_lineages_path == null || !Utils.fileExists(params.busco_lineages_path)) {
+            log.error "Path to BUSCO lineages database is not valid"
+            exit 1
+            }
+        }
+
 
     if (!params.skip_checkm) {
     // RUN CHECKM

--- a/subworkflows/local/genome_annotation.nf
+++ b/subworkflows/local/genome_annotation.nf
@@ -11,7 +11,7 @@
 
 // TODO nf-core: Add all file path parameters for the pipeline to the list below
 // Check input path parameters to see if they exist
-def checkPathParamList = [  params.multiqc_config, params.fasta ]
+def checkPathParamList = [  params.multiqc_config ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters

--- a/subworkflows/local/nanopore_raw_reads_qc.nf
+++ b/subworkflows/local/nanopore_raw_reads_qc.nf
@@ -6,7 +6,7 @@ include { PYCOQC                    } from '../../modules/nf-core/pycoqc'
 workflow NANOPORE_RAW_READS_QC {
     take:
     ch_merged_reads
-    nanopore_summary_file
+    nanopore_summary_file       // 
 
     main:
     ch_versions = Channel.empty()
@@ -41,15 +41,16 @@ workflow NANOPORE_RAW_READS_QC {
             ch_qc_reads
                 .map { [it[1]] }
                 .collect()
-                .map { reads -> [ [id: params.nanopore_summary_file_id], reads ] }
+                .map { reads ->
+                 [ [id: ( params.nanopore_summary_file ? file(nanopore_summary_file).baseName : "null" )], reads ] }
                 .set { ch_collected_reads}
 
             NANOCOMP(ch_collected_reads)
             ch_versions = ch_versions.mix(NANOCOMP.out.versions)
         }
-        if (!params.skip_pycoqc) {
+        if (!params.skip_pycoqc && params.nanopore_summary_file_id != null) {
             PYCOQC(
-                [[id: params.nanopore_summary_file_id], nanopore_summary_file]
+                [[id: file(nanopore_summary_file).baseName ], nanopore_summary_file]
             )
             ch_versions = ch_versions.mix(PYCOQC.out.versions)
         }

--- a/subworkflows/local/raw_reads_qc.nf
+++ b/subworkflows/local/raw_reads_qc.nf
@@ -31,7 +31,7 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 workflow RAW_READS_QC {
     take:
     ch_raw_reads
-
+    
 
     main:
     ch_versions = Channel.empty()
@@ -41,6 +41,17 @@ workflow RAW_READS_QC {
     raw_fastqc = Channel.empty()
     trim_fastqc = Channel.empty()
 
+
+    //
+    // Validate database paths
+    //
+
+    if (!params.skip_confindr) {
+        if (params.confindr_db == null || !Utils.fileExists(params.confindr_db)) {
+            log.error "Path to Confindr database is not valid"
+            exit 1
+            }
+        }
 
      // use rasusa to randomly subsample sequencing reads
     if (!params.skip_subsampling) {

--- a/subworkflows/local/seqqc.nf
+++ b/subworkflows/local/seqqc.nf
@@ -17,27 +17,7 @@
 // for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 
-// Check if input database paths are valid
-if (!params.skip_kraken2 && !Utils.fileExists(params.kraken2_db)) {
-    log.error "Path to Kraken2 database is not valid"
-    exit 1
-}
-if ((params.classifier == 'centrifuge') && !Utils.fileExists(params.centrifuge_db)) {
-    log.error "Path to Centrifuge database is not valid"
-    exit 1
-}
-if (!params.skip_checkm && !Utils.fileExists(params.checkm_db)) {
-    log.error "Path to CheckM database is not valid"
-    exit 1
-}
-if (!params.skip_confindr && !Utils.fileExists(params.confindr_db)) {
-    log.error "Path to Confindr database is not valid"
-    exit 1
-}
-if (!params.skip_busco && !Utils.fileExists(params.busco_lineages_path)) {
-    log.error "Path to BUSCO lineages database is not valid"
-    exit 1
-}
+
 /*
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,6 +72,41 @@ workflow SEQQC {
     ch_contigs = Channel.empty()
     ch_multiqc_files  = Channel.empty()
     ch_reads = Channel.empty()
+
+    //
+    // Validate database paths
+    //
+
+    if (!params.skip_kraken2) {
+        if ( params.kraken2_db == null || !Utils.fileExists(params.kraken2_db)) {
+                log.error "Path to Kraken2 database is not valid"
+                exit 1
+            }
+        }
+    if (params.classifier == 'centrifuge') {
+        if (params.centrifuge_db == null || !Utils.fileExists(params.centrifuge_db)) {
+                log.error "Path to Centrifuge database is not valid"
+                exit 1
+            }
+        }
+    if (!params.skip_checkm && params.checkm_db != null) {
+        if (!Utils.fileExists(params.checkm_db)) {
+            log.error "Path to CheckM database is not valid"
+            exit 1
+            }
+        }
+    if (!params.skip_confindr) {
+        if (params.confindr_db == null || !Utils.fileExists(params.confindr_db)) {
+            log.error "Path to Confindr database is not valid"
+            exit 1
+            }
+        }
+    if (!params.skip_busco) {
+        if ( params.busco_lineages_path == null || !Utils.fileExists(params.busco_lineages_path)) {
+            log.error "Path to BUSCO lineages database is not valid"
+            exit 1
+            }
+        }
 
     //
     // SUBWORKFLOW: Read in samplesheet, validate and stage input files

--- a/subworkflows/local/seqqc.nf
+++ b/subworkflows/local/seqqc.nf
@@ -74,41 +74,6 @@ workflow SEQQC {
     ch_reads = Channel.empty()
 
     //
-    // Validate database paths
-    //
-
-    if (!params.skip_kraken2) {
-        if ( params.kraken2_db == null || !Utils.fileExists(params.kraken2_db)) {
-                log.error "Path to Kraken2 database is not valid"
-                exit 1
-            }
-        }
-    if (params.classifier == 'centrifuge') {
-        if (params.centrifuge_db == null || !Utils.fileExists(params.centrifuge_db)) {
-                log.error "Path to Centrifuge database is not valid"
-                exit 1
-            }
-        }
-    if (!params.skip_checkm && params.checkm_db != null) {
-        if (!Utils.fileExists(params.checkm_db)) {
-            log.error "Path to CheckM database is not valid"
-            exit 1
-            }
-        }
-    if (!params.skip_confindr) {
-        if (params.confindr_db == null || !Utils.fileExists(params.confindr_db)) {
-            log.error "Path to Confindr database is not valid"
-            exit 1
-            }
-        }
-    if (!params.skip_busco) {
-        if ( params.busco_lineages_path == null || !Utils.fileExists(params.busco_lineages_path)) {
-            log.error "Path to BUSCO lineages database is not valid"
-            exit 1
-            }
-        }
-
-    //
     // SUBWORKFLOW: Read in samplesheet, validate and stage input files
     //
 


### PR DESCRIPTION
- Remove hardcoded paths to databases in nextflow.config
- Correct evaluation of database files
- Remove analysis of `--point` mutations in resfinder if a species is not specified
- Add paths to databases specific to the Eagle cluster in a separate config

## PR checklist

- [ X ] This comment contains a description of changes (with reason).
- [ X ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/bacpaq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/bacpaq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ X ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
