### PR TITLE
Decoupling Flye and Medaka

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -248,6 +248,25 @@ process {
         errorStrategy = 'ignore'
     }
 
+    withName: FLYE {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/${meta.mode}/FLYE" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{gfa.gz,log,fasta.gz,fa.gz,txt,gv.gz,json}'
+        ]
+        errorStrategy = 'ignore'
+    }
+
+    withName: MEDAKA {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/${meta.mode}/FLYE" },
+            mode: params.publish_dir_mode,
+            pattern: '*.fa.gz',
+            saveAs: { file -> file.replaceAll(".fa.gz", ".polished.fa.gz") }
+        ]
+        errorStrategy = 'ignore'
+    }
+
     withName: SHOVILL {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/${meta.mode}/SHOVILL" },

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -9,6 +9,7 @@ process MEDAKA {
 
     input:
     tuple val(meta), path(reads), path(assembly)
+    path(model)
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
@@ -26,7 +27,8 @@ process MEDAKA {
         $args \\
         -i $reads \\
         -d $assembly \\
-        -o ./
+        -o ./ \\
+        -m ${model}
 
     mv consensus.fasta ${prefix}.fa
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,8 +59,9 @@ params {
     // Dragonflye options
     min_input_read_len         = 1000                       // Minimum input read length (disable: 0)
     min_input_quality          = 0                          // Minimum average sequence quality (off: 0)
-    racon_rounds               = 1                          // Number of polishing rounds to conduct with Racon
-    medaka_rounds              = 1                          // Number of polishing rounds to conduct with Medaka (requires a model to be specified)
+    skip_medaka                = false                      // skip consensus sequence polishing with medaka
+    racon_rounds               = 0
+    medaka_rounds              = 0
     medaka_model               = "r1041_e82_400bps_hac_v4.3.0"       // Path to model to be used for Medaka
 
     // Taxonomy module options
@@ -127,6 +128,7 @@ params {
     skip_quast                 = false
     skip_busco                 = false
     sr_assembler               = 'spades'       // WGS_ASSEMBLY: choice of genome assembler for short read data [skesa,spades,megahit,velvet]
+    nanopore_qual              = 'raw'
 
     // CheckM options
     checkm_db                  = 'null'         // ASSEMBLY_QC: path to local CheckM lineages directory

--- a/nextflow.config
+++ b/nextflow.config
@@ -128,7 +128,7 @@ params {
     skip_quast                 = false
     skip_busco                 = false
     sr_assembler               = 'spades'       // WGS_ASSEMBLY: choice of genome assembler for short read data [skesa,spades,megahit,velvet]
-    nanopore_qual              = 'raw'
+    nanopore_qual              = 'raw'          // WGS_ASSEMBLY: quality of input nanopore reads for long-read assembly [raw,hq,corr]
 
     // CheckM options
     checkm_db                  = 'null'         // ASSEMBLY_QC: path to local CheckM lineages directory

--- a/subworkflows/local/wgs_assembly.nf
+++ b/subworkflows/local/wgs_assembly.nf
@@ -1,8 +1,9 @@
 // import modules
 include { SHOVILL    } from '../../modules/nf-core/shovill'
 include { RENAME_CTG } from '../../modules/local/rename_ctg'
-// include {  } from '../../modules/local/rename_shovill'
-include { DRAGONFLYE } from '../../modules/nf-core/dragonflye'
+include { FLYE } from '../../modules/nf-core/flye'
+include { GUNZIP; GUNZIP as GUNZIP_MEDAKA } from '../../modules/nf-core/gunzip'
+include { MEDAKA } from '../../modules/nf-core/medaka/'
 
 workflow WGS_ASSEMBLY {
     take:
@@ -11,40 +12,62 @@ workflow WGS_ASSEMBLY {
 
     main:
 
-    contigs = Channel.empty()
     corrections = Channel.empty()
     assembly_log = Channel.empty()
     raw_contigs = Channel.empty()
     gfa = Channel.empty()
-    dragonflye_info = Channel.empty()
+    flye_info = Channel.empty()
     ch_versions = Channel.empty()
-    renamed_contigs = Channel.empty()
+    renamed_contigs = Channel.empty() // polished contigs for both modes
+    illumina_contigs = Channel.empty() // polished contigs for illumina
+    nanopore_contigs = Channel.empty() // polished contigs for nanopore
 
-    //if (params.mode=="nanopore"){
+    // RUN FLYE ASSEMBLY ON NANOPORE READS
+    nanopore_qual = Channel.of("--nano-raw", "--nano-corr", "--nano-hq")
+    nanopore_qual.filter(val -> val =~ params.nanopore_qual) // determine nanopore read quality [raw, corr, hq]
+         .set { ch_nanopore_qual }
+    FLYE(nanopore_reads, ch_nanopore_qual.first())
+    GUNZIP(FLYE.out.fasta)
+    // NANOPORE POLISHING WITH MEDAKA
+    if (!params.skip_medaka) {
+        medaka_repo = "https://github.com/nanoporetech/medaka/raw/refs/heads/master/medaka/data/"
+        ch_medaka_model = Channel.from(params.medaka_model)
+            .map { model ->
+                medaka_repo+model+"_model.tar.gz"
+            }
+        ch_medaka = nanopore_reads.join(GUNZIP.out.gunzip)
+        MEDAKA(
+            ch_medaka, 
+            ch_medaka_model.first()
+        )
+        GUNZIP_MEDAKA(
+            MEDAKA.out.assembly
+        )
+        nanopore_contigs = nanopore_contigs.mix(GUNZIP_MEDAKA.out.gunzip)
+    } else {
+        nanopore_contigs = nanopore_contigs.mix(FLYE.out.fasta)
+    }
 
-    DRAGONFLYE(
-        nanopore_reads.map { meta, file ->
-            [meta, [], file]
-        }
-    )
+    // RUN ILLUMINA READ ASSEMBLY
     illumina_reads.filter { it[0].single_end == false } | SHOVILL
-    contigs = contigs.mix(DRAGONFLYE.out.contigs)
-    contigs = contigs.mix(SHOVILL.out.contigs)
+    illumina_contigs = illumina_contigs.mix(SHOVILL.out.contigs) // polished contigs
+
+    // rename contig file names for illumina assemblies ONLY
     RENAME_CTG(
-        contigs.map { tuple(it[0], it[1]) },
-        contigs.map { it[1].getName().split('\\.')[-1] },
+        illumina_contigs.map { tuple(it[0], it[1]) },
+        illumina_contigs.map { it[1].getName().split('\\.')[-1] },
     )
-    //RENAME_CTG(contigs, contigs.map { it[1].getExtension() })
-    renamed_contigs = renamed_contigs.mix(RENAME_CTG.out)
+    
+    // flye output channels
+    renamed_contigs = renamed_contigs.mix(nanopore_contigs)
+    assembly_log = assembly_log.mix(FLYE.out.log)
+    raw_contigs = raw_contigs.mix(GUNZIP.out.gunzip)
+    gfa = gfa.mix(FLYE.out.gfa)
+    flye_info = flye_info.mix(FLYE.out.txt)
+    ch_versions = ch_versions.mix(FLYE.out.versions)
 
-    //corrections = corrections.mix(DRAGONFLYE.out.corrections)
-    assembly_log = assembly_log.mix(DRAGONFLYE.out.log)
-    raw_contigs = raw_contigs.mix(DRAGONFLYE.out.raw_contigs)
-    gfa = gfa.mix(DRAGONFLYE.out.gfa)
-    dragonflye_info = dragonflye_info.mix(DRAGONFLYE.out.txt)
-    ch_versions = ch_versions.mix(DRAGONFLYE.out.versions)
-
-
+    // illumina output channels
+    renamed_contigs = renamed_contigs.mix(illumina_contigs)
     corrections = corrections.mix(SHOVILL.out.corrections)
     assembly_log = assembly_log.mix(SHOVILL.out.log)
     raw_contigs = raw_contigs.mix(SHOVILL.out.raw_contigs)
@@ -57,6 +80,6 @@ workflow WGS_ASSEMBLY {
     ch_asembly_log     = assembly_log
     ch_raw_contigs     = raw_contigs
     ch_gfa             = gfa
-    ch_dragonflye_info = dragonflye_info
+    ch_flye_info       = flye_info
     versions           = ch_versions
 }


### PR DESCRIPTION
# cidgoh/bacpaq pull request

- Deprecating `dragonflye` which is supplanted by running `flye` and `medaka` as independent processes
- Known issue: `medaka` models are not cached properly when they are fetched from the remote repo, causing the pipeline to always re-run `medaka` upon resuming..