### PR TITLE
initialize channels for pangenome tool outputs and confindr outputs t…

### DIFF
--- a/subworkflows/local/pangenome_analysis.nf
+++ b/subworkflows/local/pangenome_analysis.nf
@@ -11,6 +11,14 @@ workflow PANGENOME_ANALYSIS {
     main:
 
     ch_versions = Channel.empty()
+    roary_results = Channel.empty()
+    roary_alignment = Channel.empty()
+    pirate_results = Channel.empty()
+    pirate_alignment = Channel.empty()
+    panaroo_results = Channel.empty()
+    panaroo_alignment = Channel.empty()
+    peppan_gff = Channel.empty()
+    peppan_fna = Channel.empty()
 
     if (params.reference_gff) {
         ch_reference_gff = params.reference_gff

--- a/subworkflows/local/raw_reads_qc.nf
+++ b/subworkflows/local/raw_reads_qc.nf
@@ -34,6 +34,11 @@ workflow RAW_READS_QC {
     raw_fastqc = Channel.empty()
     trim_fastqc = Channel.empty()
 
+    confindr_csv = Channel.empty()
+    confindr_log = Channel.empty()
+    confindr_report = Channel.empty()
+    confindr_rmlst = Channel.empty()
+    aggregate_confidr = Channel.empty()
 
     //
     // Validate database paths


### PR DESCRIPTION
Initialize empty channels for confindr and pangenome tool outputs, to allow skip_confindr and to allow individual pangenome tools to be skipped without skipping pangenome analysis entirely. 



